### PR TITLE
remove python 3.11 tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ '3.8', '3.9', '3.10', '3.11' ]
+        python-version: [ '3.8', '3.9', '3.10' ]
         platform: [ ubuntu-latest ]  #  macos-latest, windows-latest
 
     steps:


### PR DESCRIPTION
they force an older version of torch and install of torchvision fails