### PR TITLE
Add non-vectorised code path to pixel count map generation

### DIFF
--- a/examples/pretrained_model.py
+++ b/examples/pretrained_model.py
@@ -1,13 +1,14 @@
 from pathlib import Path
 
 from fidder.predict.cli import predict_fiducial_mask
-from fidder.erase.cli import erase_segmented_fiducials
+from fidder.erase.cli import erase_masked_region
 
 image = Path('TS_01_0deg_bin8.mrc')
 mask = Path(image.stem + '_mask.mrc')
 probabilities = Path(image.stem + '_probabilities.mrc')
 checkpoint = Path(
-    '../training/lightning_logs/version_3123283/checkpoints/epoch=24-step=600.ckpt')
+    '../training/lightning_logs/version_3123283/checkpoints/epoch=24-step=600.ckpt'
+)
 erased = Path(image.stem + '_erased.mrc')
 
 predict_fiducial_mask(
@@ -19,7 +20,7 @@ predict_fiducial_mask(
     model_checkpoint_file=checkpoint
 )
 
-erase_segmented_fiducials(
+erase_masked_region(
     input_image=image,
     input_mask=mask,
     output=erased,

--- a/examples/quickstart.py
+++ b/examples/quickstart.py
@@ -1,7 +1,7 @@
 import mrcfile
 import torch
-from fidder.predict import predict_fiducial_mask
-from fidder.erase import erase_masked_region
+from fidder import predict_fiducial_mask
+from fidder import erase_masked_region
 
 # load your image
 image = torch.tensor(mrcfile.read('my_image_file.mrc'))

--- a/src/fidder/__init__.py
+++ b/src/fidder/__init__.py
@@ -12,8 +12,15 @@ __email__ = "alisterburt@gmail.com"
 __all__ = ["__version__", "cli", "Fidder", "train_fidder", "download_training_data"]
 
 from ._cli import cli
-from .model import Fidder
-from .data import download_training_data
+# cli tools
 from .train import train_fidder
 from .predict.cli import predict_fiducial_mask
-from .erase.cli import erase_segmented_fiducials
+from .erase.cli import erase_masked_region
+
+# python things
+from .model import Fidder
+from .data import download_training_data
+from .predict import predict_fiducial_mask
+from .erase import erase_masked_region
+
+

--- a/src/fidder/_tests/test_utils.py
+++ b/src/fidder/_tests/test_utils.py
@@ -1,13 +1,13 @@
 import torch
 
-from fidder.utils import connected_component_transform_2d
+from fidder.utils import pixel_count_map_2d
 
 
 def test_connected_component_transform_2d():
     mask = torch.zeros((10, 10))
     mask[::2, ::2] = 1
     mask[1::2, 1::2] = 1
-    connected_component_image = connected_component_transform_2d(mask).long()
+    connected_component_image = pixel_count_map_2d(mask).long()
     assert torch.allclose(
         connected_component_image[::2, ::2], torch.tensor(1).long())
     assert torch.allclose(

--- a/src/fidder/erase/cli.py
+++ b/src/fidder/erase/cli.py
@@ -11,7 +11,7 @@ from .._cli import cli, OPTION_PROMPT_KWARGS as PKWARGS
 
 
 @cli.command(name="erase", no_args_is_help=True)
-def erase_segmented_fiducials(
+def erase_masked_region(
     input_image: Path = Option(
         default=...,
         help="Image file in MRC format.",

--- a/src/fidder/predict/probabilities_to_mask.py
+++ b/src/fidder/predict/probabilities_to_mask.py
@@ -1,5 +1,5 @@
 import torch
-from ..utils import connected_component_transform_2d
+from ..utils import pixel_count_map_2d
 
 
 def probabilities_to_mask(
@@ -27,6 +27,6 @@ def probabilities_to_mask(
         `(h, w)` boolean array.
     """
     mask = probabilities > threshold
-    pixel_count_map = connected_component_transform_2d(mask)
+    pixel_count_map = pixel_count_map_2d(mask)
     mask[pixel_count_map < connected_pixel_count_threshold] = 0
     return mask

--- a/src/fidder/train.py
+++ b/src/fidder/train.py
@@ -22,8 +22,7 @@ def train_fidder(
 
     trainer = Trainer(
         accelerator="auto",
-        devices=1,
-        auto_select_gpus=True,
+        devices="auto",
         default_root_dir=output_directory,
         max_steps=gradient_steps,
         log_every_n_steps=10,


### PR DESCRIPTION
The previous code was not memory efficient when there were large numbers of disconnected regions in a segmentation, leading to out of memory errors - this is now handled by an alternative, non-vectorised code path which is more memory efficient.

includes #23 