### PR TITLE
Reference XDG_CACHE_HOME in the documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,9 @@ If trying to use an `10.X` CUDA runtime you may have to install older versions o
 `torch` and `pytorch-lightning`, see 
 [teamtomo/fidder#17](https://github.com/teamtomo/fidder/issues/17) for details.
 
+### Model weights cache directory
+Fidder will fetch the needed weights from Zenodo on its first run. To do so, [pooch](https://www.fatiando.org/pooch/latest/index.html) is used to download the weights to your computer. In Unix-like systems, this will [default](https://www.fatiando.org/pooch/latest/api/generated/pooch.os_cache.html#pooch-os-cache) to _~/.cache/fidder_ unless XDG_CACHE_HOME is set to a different location. 
+
 ## Notes
 
 This package provides similar functionality to 

--- a/docs/index.md
+++ b/docs/index.md
@@ -86,7 +86,7 @@ If trying to use an `10.X` CUDA runtime you may have to install older versions o
 `torch` and `pytorch-lightning`, see 
 [teamtomo/fidder#17](https://github.com/teamtomo/fidder/issues/17) for details.
 
-### Model weights cache directory
+## Model weights cache directory
 Fidder will fetch the needed weights from Zenodo on its first run. To do so, [pooch](https://www.fatiando.org/pooch/latest/index.html) is used to download the weights to your computer. In Unix-like systems, this will [default](https://www.fatiando.org/pooch/latest/api/generated/pooch.os_cache.html#pooch-os-cache) to _~/.cache/fidder_ unless XDG_CACHE_HOME is set to a different location. 
 
 # Notes

--- a/docs/index.md
+++ b/docs/index.md
@@ -84,7 +84,10 @@ pip install fidder
 
 If trying to use an `10.X` CUDA runtime you may have to install older versions of 
 `torch` and `pytorch-lightning`, see 
-[teamtomo/fidder#17](https://github.com/teamtomo/fidder/issues/17) for details.
+[teamtomo/fidder#17](https://github.com/teamtomo/fidder/issues/17) for details
+
+### Model weights cache directory
+Fidder will fetch the needed weights from Zenodo on its first run. To do so, [pooch](https://www.fatiando.org/pooch/latest/index.html) is used to download the weights to your computer. In Unix-like systems, this will [default](https://www.fatiando.org/pooch/latest/api/generated/pooch.os_cache.html#pooch-os-cache) to _~/.cache/fidder_ unless XDG_CACHE_HOME is set to a different location. 
 
 # Notes
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -84,7 +84,7 @@ pip install fidder
 
 If trying to use an `10.X` CUDA runtime you may have to install older versions of 
 `torch` and `pytorch-lightning`, see 
-[teamtomo/fidder#17](https://github.com/teamtomo/fidder/issues/17) for details
+[teamtomo/fidder#17](https://github.com/teamtomo/fidder/issues/17) for details.
 
 ### Model weights cache directory
 Fidder will fetch the needed weights from Zenodo on its first run. To do so, [pooch](https://www.fatiando.org/pooch/latest/index.html) is used to download the weights to your computer. In Unix-like systems, this will [default](https://www.fatiando.org/pooch/latest/api/generated/pooch.os_cache.html#pooch-os-cache) to _~/.cache/fidder_ unless XDG_CACHE_HOME is set to a different location. 


### PR DESCRIPTION
A specific subset of users might encounter problems while trying to use Fidder when pooch does not have access to the [default expected cache directory](https://www.fatiando.org/pooch/latest/api/generated/pooch.os_cache.html#pooch.os_cache), which is _~/.cache/fidder_ in Unix-like systems.

An easy fix to this is to inform the non-advanced users about the XDG_CACHE_HOME variable, which can be used to change the default behavior. That's why I'm proposing adding it to both the GitHub Repo landing page as well as the MkDocs page MD files, as a shortcut for users with limited knowledge in these systems.